### PR TITLE
MD-03: Connect Camera(s) To Docker Containers

### DIFF
--- a/config/docker-compose-template.yml
+++ b/config/docker-compose-template.yml
@@ -19,8 +19,9 @@ services:
       - ../../machx_code:/home/${CONTAINER_USER}/machx_code
       - ../volumes/entrypoint.sh:/home/${CONTAINER_USER}/entrypoint.sh
       - ../volumes/hosts:/etc/hosts
-    entrypoint: ["/home/${CONTAINER_USER}/entrypoint.sh"]
-
+    devices:
+      - "/dev/video0:/dev/video0"
+    entrypoint: [ "/home/${CONTAINER_USER}/entrypoint.sh" ]
 networks:
   mynetwork:
     ipam:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,10 +1,13 @@
-FROM ros:iron-perception-jammy
+FROM ros:iron-ros-base
 
 RUN apt-get update && \
     apt-get install -y \
-    python3-pip \
+    libopencv-dev \
     net-tools \
+    python3-opencv \
+    python3-pip \
     tree \
+    v4l-utils \ 
     vim \
     wget && \
     rosdep update && \

--- a/volumes/entrypoint.sh
+++ b/volumes/entrypoint.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
+USERNAME=$(whoami)
+
 echo "Running Entrypoint"
+
+# Source the ROS setup script
 source /opt/ros/iron/setup.bash
 echo "source /opt/ros/iron/setup.bash" >> ~/.bashrc
+
+# Change ownership of video devices to current user and
+# set appropriate permissons
+sudo chown $USERNAME:video /dev/video*
+sudo chmod 660 /dev/video*
 
 # Keep the container running
 exec tail -f /dev/null


### PR DESCRIPTION
### Problem
[MD-03: Connect Camera(s) To Docker Containers](https://app.asana.com/0/1208603489147862/1208632600213599/f)
- Need to mount video devices on to the docker container.
- When mounting the video devices, camera permission issues occurs when trying to run camera server node in container.

### Solution
- Add `/dev/video0` as a volume in `docker-compose-template.yml`.
- Modify `entrypoint.sh` to update permission and ownership of `/dev/video*` to container.

### Notes
- So far only the camera server was tested. Still need to test whether camera client works.
- Might have to find a better way to mount all video devices. Docker compose doesn't support wildcards